### PR TITLE
Limit bucket name to 63 chars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "prevent_unencrypted_uploads" {
 }
 
 resource "aws_s3_bucket" "default" {
-  bucket        = module.s3_bucket_label.id
+  bucket        = substr(module.s3_bucket_label.id, 0, 63)
   acl           = var.acl
   region        = var.region
   force_destroy = var.force_destroy


### PR DESCRIPTION
As per S3 specs, buckets cannot be more than 63 characters long